### PR TITLE
Feat hierarchical

### DIFF
--- a/examples/hierarchical.rs
+++ b/examples/hierarchical.rs
@@ -1,0 +1,12 @@
+use chordclust::{cluster_hierarchical, read_fasta_sorted};
+use std::fs::File;
+use std::io::BufReader;
+
+fn main() {
+    let f = File::open("examples/UP000000425_122586_DNA_sample.fasta").unwrap();
+    let reader = BufReader::new(f);
+    let sequences = read_fasta_sorted(reader);
+    let similarity_thresholds = &[100, 90, 85, 65, 30, 20];
+    let cluster_db = cluster_hierarchical(&sequences, 8, similarity_thresholds);
+    println!("{:#?}", cluster_db.clusters)
+}

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,13 +1,15 @@
 use bio::alignment::sparse::{find_kmer_matches_seq1_hashed, lcskpp};
 use bio::alignment::sparse::{hash_kmers, HashMapFx};
+use std::collections::HashMap;
+use std::convert::AsMut;
 
 /// Container for a centroid and the indexes of them.
 #[derive(Default)]
 pub struct Cluster<'c> {
     /// each sequence in the cluster
-    members: Vec<&'c str>,
+    pub(crate) members: Vec<&'c str>,
     /// sequence that forms the centroid
-    centroid: &'c str,
+    pub(crate) centroid: &'c str,
     /// hashed centromer to perform search and similarity
     pub hashed_centroid: HashMapFx<&'c [u8], Vec<u32>>,
 }
@@ -37,7 +39,7 @@ impl<'a> std::fmt::Debug for Cluster<'a> {
 /// have s similarity > `similarity_threshold` with the centroid
 pub struct BucketCluster<'a> {
     /// Clusters with a similarity threshold around the centroid
-    pub clusters: Vec<Cluster<'a>>,
+    pub clusters: HashMap<&'a str, Cluster<'a>>,
     /// Size of k-mers to perform the search
     k: usize,
     /// Minimum similarity with the centroid to become part of a cluster
@@ -48,34 +50,57 @@ impl<'c> BucketCluster<'c> {
     /// Initialize empty bucket of clusters
     pub fn new(k: usize, similarity_threshold: u32) -> Self {
         BucketCluster {
-            clusters: Vec::new(),
+            clusters: HashMap::new(),
             k,
             similarity_threshold,
         }
     }
 
-    fn get_best_cluster(&self, seq: &str) -> Option<usize> {
+    fn get_best_cluster(&self, seq: &'c str) -> Option<&str> {
         let query = seq.as_bytes();
         let mut max_score = 0;
-        let mut best_idx: Option<usize> = None;
-        for (i, center) in self.clusters.iter().enumerate() {
-            let matches = find_kmer_matches_seq1_hashed(&center.hashed_centroid, query, self.k);
+        let mut best_idx: Option<&str> = None;
+        for (&centroid, cluster) in self.clusters.iter() {
+            let matches = find_kmer_matches_seq1_hashed(&cluster.hashed_centroid, query, self.k);
             let score = lcskpp(&matches, self.k).score;
             if score > self.similarity_threshold && max_score < score {
-                best_idx = Some(i);
+                best_idx = Some(centroid);
                 max_score = score;
             }
         }
         best_idx
     }
 
+    fn match_best_cluster(&mut self, seq: &'c str) {
+        let query = seq.as_bytes();
+        let mut max_score = 0;
+        let mut best_idx: Option<&str> = None;
+        for (&centroid, cluster) in self.clusters.iter() {
+            let matches = find_kmer_matches_seq1_hashed(&cluster.hashed_centroid, query, self.k);
+            let score = lcskpp(&matches, self.k).score;
+            if score > self.similarity_threshold && max_score < score {
+                best_idx = Some(centroid);
+                max_score = score;
+            }
+        }
+        if let Some(idx) = best_idx {
+            self.clusters.entry(idx).or_default().push(seq);
+        } else {
+            // TODO: remove this unwrap
+            self.clusters.insert(seq, Cluster::new(seq, self.k));
+        }
+    }
+
     /// Add the sequence to the best matched cluster or create a new cluster
     /// if the sequence is not inside the threshold of any centroid
     pub fn push(&mut self, seq: &'c str) {
-        if let Some(idx) = self.get_best_cluster(seq) {
-            self.clusters[idx].push(seq);
-        } else {
-            self.clusters.push(Cluster::new(seq, self.k))
-        }
+        self.match_best_cluster(seq);
+        // if let Some(idx) = self.get_best_cluster(seq) {
+        //     let clust = &mut self.clusters.entry(idx);
+        //     clust.or_default().members.push(seq);
+        // } else {
+        //     // TODO: remove this unwrap
+        //     self.clusters.insert(seq, Cluster::new(seq, self.k)).unwrap();
+        // }
     }
 }

--- a/src/hierarchical.rs
+++ b/src/hierarchical.rs
@@ -33,7 +33,7 @@ pub fn cluster_hierarchical<'a>(
             .for_each(|seq| cluster_db.push(seq));
         cluster_dbs.push(cluster_db);
     }
-    // start from the second highest cluster, expanding the clusters 
+    // start from the second highest cluster, expanding the clusters
     // from their parents (which are centroids of the previous cluster)
     cluster_dbs.reverse();
     // we keep the cluster above the one being expanded

--- a/src/hierarchical.rs
+++ b/src/hierarchical.rs
@@ -1,0 +1,74 @@
+use super::cluster::BucketCluster;
+
+/// Cluster a slice of `String`s by similarity in a groups inside a similarity
+/// threshold around the centroids. The centroids are then passed to a second
+/// clustering process as sequences to be clustered with a lower treshold.
+///
+/// # Examples
+/// ```
+/// use std::fs::File;
+/// use std::io::BufReader;
+/// use chordclust::{read_fasta_sorted, cluster_slice};
+///
+/// let f = File::open("examples/UP000000425_122586_DNA_sample.fasta").unwrap();
+/// let reader = BufReader::new(f);
+/// let sequences = read_fasta_sorted(reader);
+/// let cluster_db = cluster_slice(&sequences, 8, 85);
+/// let n_clusters = cluster_db.clusters.len();
+/// assert!(1 < n_clusters);
+/// assert!(n_clusters < sequences.len());
+/// ```
+pub fn cluster_hierarchical<'a>(
+    sequences: &'a [String],
+    k: usize,
+    similarity_thresholds: &'a [u32],
+) -> BucketCluster<'a> {
+    let mut cluster_db = BucketCluster::new(k, similarity_thresholds[0]);
+    for seq in sequences.iter() {
+        cluster_db.push(seq);
+    }
+    let mut cluster_dbs: Vec<BucketCluster> = Vec::with_capacity(similarity_thresholds.len() - 1);
+    cluster_dbs.push(cluster_db);
+    for (i, &threshold) in similarity_thresholds.iter().enumerate() {
+        let mut cluster_db = BucketCluster::new(k, threshold);
+        cluster_dbs[i]
+            .clusters
+            .iter()
+            .map(|(_, cluster)| cluster.centroid)
+            .for_each(|seq| cluster_db.push(seq));
+        cluster_dbs.push(cluster_db);
+    }
+    cluster_dbs.reverse();
+    let mut clust_above = cluster_dbs.pop().unwrap();
+    while let Some(mut bucket) = cluster_dbs.pop() {
+        bucket.clusters.iter_mut().for_each(|(_, cluster)| {
+            let ll = cluster.members.clone();
+            let cluster_new = ll
+                .iter()
+                .flat_map(|seq| clust_above.clusters[seq].members.clone());
+            cluster.members.extend(cluster_new);
+        });
+        clust_above = bucket;
+    }
+
+    clust_above
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::read_fasta_sorted;
+    use std::fs::File;
+    use std::io::BufReader;
+    #[test]
+    fn cluster_hierarchical_works() {
+        let f = File::open("examples/UP000000425_122586_DNA_sample.fasta").unwrap();
+        let reader = BufReader::new(f);
+        let sequences = read_fasta_sorted(reader);
+        let thresholds = [90, 85, 70];
+        let cluster_db = cluster_hierarchical(&sequences, 8, &thresholds);
+        let n_clusters = cluster_db.clusters.len();
+        assert!(1 < n_clusters);
+        assert!(n_clusters < sequences.len());
+    }
+}

--- a/src/hierarchical.rs
+++ b/src/hierarchical.rs
@@ -4,20 +4,14 @@ use super::cluster::BucketCluster;
 /// threshold around the centroids. The centroids are then passed to a second
 /// clustering process as sequences to be clustered with a lower treshold.
 ///
-/// # Examples
-/// ```
-/// use std::fs::File;
-/// use std::io::BufReader;
-/// use chordclust::{read_fasta_sorted, cluster_slice};
+/// Given that all the members of a cluster are centroids of the clusters in
+/// the previous iteration, the final structure is built by expanding the lowest
+/// similiarity cluster with its parents until the higher similarity cluster
+/// is processed.
 ///
-/// let f = File::open("examples/UP000000425_122586_DNA_sample.fasta").unwrap();
-/// let reader = BufReader::new(f);
-/// let sequences = read_fasta_sorted(reader);
-/// let cluster_db = cluster_slice(&sequences, 8, 85);
-/// let n_clusters = cluster_db.clusters.len();
-/// assert!(1 < n_clusters);
-/// assert!(n_clusters < sequences.len());
-/// ```
+/// See an [example on the repository](https://github.com/carrascomj/chordclust/blob/trunk/examples/hierarchical.rs).
+///
+/// Internally, this is implemented starting from the top with dynamic programming.
 pub fn cluster_hierarchical<'a>(
     sequences: &'a [String],
     k: usize,
@@ -27,6 +21,7 @@ pub fn cluster_hierarchical<'a>(
     for seq in sequences.iter() {
         cluster_db.push(seq);
     }
+    // perform all hierarchical steps from the previous centroids
     let mut cluster_dbs: Vec<BucketCluster> = Vec::with_capacity(similarity_thresholds.len() - 1);
     cluster_dbs.push(cluster_db);
     for (i, &threshold) in similarity_thresholds.iter().enumerate() {
@@ -38,7 +33,10 @@ pub fn cluster_hierarchical<'a>(
             .for_each(|seq| cluster_db.push(seq));
         cluster_dbs.push(cluster_db);
     }
+    // start from the second highest cluster, expanding the clusters 
+    // from their parents (which are centroids of the previous cluster)
     cluster_dbs.reverse();
+    // we keep the cluster above the one being expanded
     let mut clust_above = cluster_dbs.pop().unwrap();
     while let Some(mut bucket) = cluster_dbs.pop() {
         bucket.clusters.iter_mut().for_each(|(_, cluster)| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! approach:
 //!
 //! 1. Given the sequences to cluster `seqs` and a descending array of
-//! similarity thresholds `[T]`. 
+//! similarity thresholds `[T]`.
 //! 2. For each similarity threshold `T` in `[T]`:
 //!   * Apply clustering with T to `seqs`
 //!   * seqs <- current centroids

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,11 @@
 //! 2. For each sequence, compare it with the database of centroids:
 //!   * If identity with best match > T: add to cluster of best match.
 //!   * Else: form a new cluster.
-mod cluster;
+pub mod cluster;
 use cluster::BucketCluster;
+
+mod hierarchical;
+pub use hierarchical::cluster_hierarchical;
 
 use bio::io::fasta;
 use std::io::Read;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,24 @@
 //! ## Algorithm
 //! The algorithm is a greedy search, similar to what is explained in
 //! https://www.drive5.com/usearch/manual/uclust_algo.html. It uses similarity
-//! instead of identity (for now)
+//! instead of identity (for now):
 //!
-//! 1. Sort by sequence length (bigger is first).
+//! 1. Sort by sequence length (bigger is first)
 //! 2. For each sequence, compare it with the database of centroids:
-//!   * If identity with best match > T: add to cluster of best match.
-//!   * Else: form a new cluster.
+//!   * If identity with best match > T: add to cluster of best match
+//!   * Else: form a new cluster
+//!
+//! ## Hierarchical
+//! With this kind of heuristic clustering, it is indicated to use a hierarchical
+//! approach:
+//!
+//! 1. Given the sequences to cluster `seqs` and a descending array of
+//! similarity thresholds `[T]`. 
+//! 2. For each similarity threshold `T` in `[T]`:
+//!   * Apply clustering with T to `seqs`
+//!   * seqs <- current centroids
+//! 3. The final structure is built by expanding the lower similarity clusters
+//! with the members of their corresponding higher clusters.
 pub mod cluster;
 use cluster::BucketCluster;
 


### PR DESCRIPTION
# Description 
Implement hierarchical clustering.
With this kind of heuristic clustering, it is indicated to use a hierarchical
approach:

1. Given the sequences to cluster `seqs` and a descending array of
similarity thresholds `[T]`. 
2. For each similarity threshold `T` in `[T]`:
  * Apply clustering with T to `seqs`
  * seqs <- current centroids
3. The final structure is built by expanding the lower similarity clusters.

# Implementation
* A public function was added.
* The inner `clusters` structure of `BucketCluster` was changed from `Vec` to `HashMap`. This way is easier to search for the clusters by centroid in the reconstruction of the final structure.
* The final structure was implemented from top to bottom, in a dynamic programming fashion. 