### PR TITLE
Perf: remove some clones

### DIFF
--- a/src/hierarchical.rs
+++ b/src/hierarchical.rs
@@ -43,10 +43,12 @@ pub fn cluster_hierarchical<'a>(
     let mut clust_above = cluster_dbs.pop().unwrap();
     while let Some(mut bucket) = cluster_dbs.pop() {
         bucket.clusters.iter_mut().for_each(|(_, cluster)| {
-            let ll = cluster.members.clone();
-            cluster.members.extend(ll.iter().flat_map(|seq| {
-                std::mem::take(&mut clust_above.clusters.get_mut(seq).unwrap().members)
-            }))
+            for i in 0..cluster.members.len() {
+                let seq = cluster.members[i];
+                cluster.members.extend(std::mem::take(
+                    &mut clust_above.clusters.get_mut(seq).unwrap().members,
+                ));
+            }
         });
         clust_above = bucket;
     }

--- a/src/hierarchical.rs
+++ b/src/hierarchical.rs
@@ -44,10 +44,9 @@ pub fn cluster_hierarchical<'a>(
     while let Some(mut bucket) = cluster_dbs.pop() {
         bucket.clusters.iter_mut().for_each(|(_, cluster)| {
             let ll = cluster.members.clone();
-            let cluster_new = ll
-                .iter()
-                .flat_map(|seq| clust_above.clusters[seq].members.clone());
-            cluster.members.extend(cluster_new);
+            cluster.members.extend(ll.iter().flat_map(|seq| {
+                std::mem::take(&mut clust_above.clusters.get_mut(seq).unwrap().members)
+            }))
         });
         clust_above = bucket;
     }


### PR DESCRIPTION
### Description
Two clones were removed in favor of [std::mem::take](https://doc.rust-lang.org/std/mem/fn.take.html) on the reconstruction of the clusters in the hierarchical pass. 

### Changes
No performance change (in CPU nor time) but better memory profile. The reconstruction of clusters is by no means a bottleneck (for now) but it may be problematic with very big files in terms of memory.